### PR TITLE
Scrollable functionality for Related Products carousel + possible fix for cart.jsx bug

### DIFF
--- a/reducers/main.js
+++ b/reducers/main.js
@@ -4,14 +4,15 @@ import thumbnails from './thumbnails';
 import relatedStyles from './relatedStyles';
 import outfit from './outfit';
 import relatedProductsReducer from './relatedProducts';
-
+import userOutfitsReducer from './userOutfits';
 
 const rootReducer = combineReducers({
   styleList,
   thumbnails,
   relatedStyles,
   outfit,
-  relatedProducts: relatedProductsReducer
+  relatedProducts: relatedProductsReducer,
+  userOutfits: userOutfitsReducer
 
 });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,7 @@ class App extends React.Component {
           </div>
           </div>
         </div>
-        <RelatedProducts />
+        {/* <RelatedProducts /> */}
       </>
     );
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,7 @@ class App extends React.Component {
         <h1>
           Project Catwalk App
         </h1>
-        <div className="productOverview">
+        {/* <div className="productOverview">
           <div className="shownImage">
             <StyleVisualContainer />
           </div>
@@ -50,8 +50,8 @@ class App extends React.Component {
           <CartContainer />
           </div>
           </div>
-        </div>
-        {/* <RelatedProducts /> */}
+        </div> */}
+        <RelatedProducts />
       </>
     );
   }

--- a/src/components/ProductTile.js
+++ b/src/components/ProductTile.js
@@ -99,24 +99,32 @@ const ProductTile = ({ tileType, currentId, relId }) => {
     return payload;
   }
 
+
   useEffect(() => {
-    if (tileType === 'related') {
-      fetchAllRelevantData(tileType)
-        .then((result) => {
-          const payload = createPayload();
-          setTile(payload);
-          return payload;
-        })
-        .then((payload) => {
+
+    fetchAllRelevantData(tileType)
+      .then((result) => {
+        const payload = createPayload();
+        setTile(payload);
+        return payload;
+      })
+      .then((payload) => {
+        if (tileType === 'related') {
           dispatch({
             type: 'ADD_RELATED_PRODUCT',
             payload
           });
-        })
-        .catch((err) => {
-          throw err;
-        });
-    }
+        } else if (tileType === 'outfit') {
+          // dispatch({
+          //   type: 'ADD_USER_OUTFIT',
+          //   payload
+          // });
+        }
+      })
+      .catch((err) => {
+        throw err;
+      });
+
   }, [])
 
   return (

--- a/src/components/ProductTile.js
+++ b/src/components/ProductTile.js
@@ -15,52 +15,52 @@ const ProductTile = ({ tileType, currentId, relId }) => {
   let meta = {};
   const [tile, setTile] = useState({});
 
-  const fetchDetails = (fetchType) => {
-    if (fetchType === 'related') {
-      return axios.get(`/products/${relId}`)
-        .then(({data}) => {
-          details = data;
-          return data;
-        })
-        .catch((err) => {
-          throw err;
-        })
-    }
+  let target;
+  if (tileType === 'related') {
+    target = relId
+  } else if (tileType === 'outfit') {
+    target = currentId
   }
 
-  const fetchStyles = (fetchType) => {
-    if (fetchType === 'related') {
-      return axios.get(`/products/${relId}/styles`)
-        .then(({data}) => {
-          // console.log('related prod styles:', data.results);
-          styles = data.results;
-          return data.results;
-        })
-        .catch((err) => {
-          throw err;
-        })
-    }
-  }
-
-  const fetchMeta = (fetchType) => {
-    if (fetchType === 'related') {
-      return axios.get('/reviews/meta', {
-        params: {
-          product_id: relId
-        }
+  const fetchDetails = () => (
+    axios.get(`/products/${target}`)
+      .then(({data}) => {
+        details = data;
+        return data;
       })
-        .then(({data}) => {
-          meta = data;
-          return data;
-        })
-        .catch((err) => {
-          throw err;
-        })
-    }
-  }
+      .catch((err) => {
+        throw err;
+      })
+  )
 
-  const fetchAllRelevantData = (fetchType) => (
-    Promise.all([fetchDetails(fetchType), fetchStyles(fetchType), fetchMeta(fetchType)])
+  const fetchStyles = () => (
+    axios.get(`/products/${target}/styles`)
+      .then(({data}) => {
+        styles = data.results;
+        return data.results;
+      })
+      .catch((err) => {
+        throw err;
+      })
+  )
+
+  const fetchMeta = () => (
+    axios.get('/reviews/meta', {
+      params: {
+        product_id: target
+      }
+    })
+      .then(({data}) => {
+        meta = data;
+        return data;
+      })
+      .catch((err) => {
+        throw err;
+      })
+  )
+
+  const fetchAllRelevantData = () => (
+    Promise.all([fetchDetails(), fetchStyles(), fetchMeta()])
       .catch((err) => {
         console.log(err);
       })
@@ -102,7 +102,7 @@ const ProductTile = ({ tileType, currentId, relId }) => {
 
   useEffect(() => {
 
-    fetchAllRelevantData(tileType)
+    fetchAllRelevantData()
       .then((result) => {
         const payload = createPayload();
         setTile(payload);
@@ -115,10 +115,10 @@ const ProductTile = ({ tileType, currentId, relId }) => {
             payload
           });
         } else if (tileType === 'outfit') {
-          // dispatch({
-          //   type: 'ADD_USER_OUTFIT',
-          //   payload
-          // });
+          dispatch({
+            type: 'ADD_USER_OUTFIT',
+            payload
+          });
         }
       })
       .catch((err) => {

--- a/src/components/ProductTile.js
+++ b/src/components/ProductTile.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 /* eslint-disable no-restricted-syntax */
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -5,7 +6,7 @@ import axios from 'axios';
 import StarRatings from './tiles-subcomps/StarRatings';
 
 
-const RelatedProductTile = ({ currentId, relId }) => {
+const ProductTile = ({ tileType, currentId, relId }) => {
 
   const dispatch = useDispatch();
 
@@ -14,46 +15,52 @@ const RelatedProductTile = ({ currentId, relId }) => {
   let meta = {};
   const [tile, setTile] = useState({});
 
-  const fetchDetails = () => (
-    axios.get(`/products/${relId}`)
-      .then(({data}) => {
-        details = data;
-        return data;
-      })
-      .catch((err) => {
-        throw err;
-      })
-  )
+  const fetchDetails = (fetchType) => {
+    if (fetchType === 'related') {
+      return axios.get(`/products/${relId}`)
+        .then(({data}) => {
+          details = data;
+          return data;
+        })
+        .catch((err) => {
+          throw err;
+        })
+    }
+  }
 
-  const fetchStyles = () => (
-    axios.get(`/products/${relId}/styles`)
-      .then(({data}) => {
-        // console.log('related prod styles:', data.results);
-        styles = data.results;
-        return data.results;
-      })
-      .catch((err) => {
-        throw err;
-      })
-  )
+  const fetchStyles = (fetchType) => {
+    if (fetchType === 'related') {
+      return axios.get(`/products/${relId}/styles`)
+        .then(({data}) => {
+          // console.log('related prod styles:', data.results);
+          styles = data.results;
+          return data.results;
+        })
+        .catch((err) => {
+          throw err;
+        })
+    }
+  }
 
-  const fetchMeta = () => (
-    axios.get('/reviews/meta', {
-      params: {
-        product_id: relId
-      }
-    })
-      .then(({data}) => {
-        meta = data;
-        return data;
+  const fetchMeta = (fetchType) => {
+    if (fetchType === 'related') {
+      return axios.get('/reviews/meta', {
+        params: {
+          product_id: relId
+        }
       })
-      .catch((err) => {
-        throw err;
-      })
-  )
+        .then(({data}) => {
+          meta = data;
+          return data;
+        })
+        .catch((err) => {
+          throw err;
+        })
+    }
+  }
 
-  const fetchAllRelevantData = () => (
-    Promise.all([fetchDetails(), fetchStyles(), fetchMeta()])
+  const fetchAllRelevantData = (fetchType) => (
+    Promise.all([fetchDetails(fetchType), fetchStyles(fetchType), fetchMeta(fetchType)])
       .catch((err) => {
         console.log(err);
       })
@@ -93,22 +100,24 @@ const RelatedProductTile = ({ currentId, relId }) => {
   }
 
   useEffect(() => {
-    fetchAllRelevantData()
-      .then((result) => {
-        const payload = createPayload();
-        setTile(payload);
-        return payload;
-      })
-      .then((payload) => {
-        dispatch({
-          type: 'ADD_RELATED_PRODUCT',
-          payload
+    if (tileType === 'related') {
+      fetchAllRelevantData(tileType)
+        .then((result) => {
+          const payload = createPayload();
+          setTile(payload);
+          return payload;
+        })
+        .then((payload) => {
+          dispatch({
+            type: 'ADD_RELATED_PRODUCT',
+            payload
+          });
+        })
+        .catch((err) => {
+          throw err;
         });
-      })
-      .catch((err) => {
-        throw err;
-      });
-    }, [])
+    }
+  }, [])
 
   return (
     // each tile 184px + 5px column gap
@@ -131,8 +140,8 @@ const RelatedProductTile = ({ currentId, relId }) => {
           <span className="tile-price full-price">{tile.defaultPrice}</span>
         </div> :
         <div className="tile-price">{tile.defaultPrice}</div>}
-        <StarRatings className="tile-stars" data={tile}/>
       </div>
+      <StarRatings className="tile-stars" data={tile}/>
 
 
     </li>
@@ -141,5 +150,5 @@ const RelatedProductTile = ({ currentId, relId }) => {
 };
 
 
-export default RelatedProductTile;
+export default ProductTile;
 

--- a/src/components/RelatedProductTile.js
+++ b/src/components/RelatedProductTile.js
@@ -28,6 +28,7 @@ const RelatedProductTile = ({ currentId, relId }) => {
   const fetchStyles = () => (
     axios.get(`/products/${relId}/styles`)
       .then(({data}) => {
+        // console.log('related prod styles:', data.results);
         styles = data.results;
         return data.results;
       })
@@ -75,7 +76,7 @@ const RelatedProductTile = ({ currentId, relId }) => {
     const payload = {
       name: details.name,
       category: details.category,
-      defaultPrice: details.default_price,
+      defaultPrice: `$${details.default_price}`,
       features: details.features,
       ratings: calcAvgRatings(meta.ratings),
       photos: styles[0].photos
@@ -110,20 +111,30 @@ const RelatedProductTile = ({ currentId, relId }) => {
     }, [])
 
   return (
-    <li>
-      {
-        tile.photos ?
-        <img className="relatedProd-image" src={tile.photos[0].url || 'https://source.unsplash.com/200x100/?corgi'} alt={tile.name} width="150"/> :
-        <></>
-      }
-      <div>{tile.category}</div>
-      <div>{tile.name}</div>
-      {
-        tile.salePrice ?
-        <div>{tile.salePrice}</div> :
-        <div>{tile.defaultPrice}</div>
-      }
-      <StarRatings data={tile}/>
+    // each tile 184px + 5px column gap
+    <li className="tile">
+
+      <div className="tile-img-container">
+        {tile.photos ?
+        <img className="tile-img" src={tile.photos[0].url || 'https://source.unsplash.com/200x100/?corgi'} alt={tile.name} width="150"/> :
+        <></>}
+      </div>
+
+      <div className="tile-texts-container">
+        <div className="tile-category">{tile.category}</div>
+
+        <div className="tile-name">{tile.name}</div>
+
+        {tile.salePrice ?
+        <div className="tile-price-container">
+          <span className="tile-price sale-price">  {`$${tile.salePrice}`}</span>
+          <span className="tile-price full-price">{tile.defaultPrice}</span>
+        </div> :
+        <div className="tile-price">{tile.defaultPrice}</div>}
+        <StarRatings className="tile-stars" data={tile}/>
+      </div>
+
+
     </li>
   );
 

--- a/src/components/RelatedProducts.js
+++ b/src/components/RelatedProducts.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
@@ -6,6 +8,7 @@ import RelatedProductTile from './RelatedProductTile';
 const RelatedProducts = () => {
 
   const [relatedIds, setRelatedIds] = useState([]);
+  const [scrollPos, setScrollPos] = useState(0);
   const currentProductId = useSelector(state => state.styleList.product_id); // string 11001
 
   const fetchRelatedProductsIds = () => {
@@ -22,15 +25,33 @@ const RelatedProducts = () => {
     fetchRelatedProductsIds();
   }, [])
 
+  const handlePrevScroll = () => {
+    document.getElementById('tiles').scrollLeft -= 189;
+    setScrollPos(scrollPos - 1);
+  }
+
+  const handleNextScroll = () => {
+    document.getElementById('tiles').scrollLeft += 189;
+    setScrollPos(scrollPos + 1);
+  }
 
   return (
     <div>
-      Related Products Component
-      <ol>
-        {relatedIds.map((id) => (
-          <RelatedProductTile currentId={currentProductId} relId={id} key={id}/>
-        ))}
-      </ol>
+      <span>Related Products</span>
+      <div id="RP-wrapper">
+          {scrollPos !== 0 ?
+          <span className="prev-arrow" onClick={handlePrevScroll}>&lsaquo;</span> :
+          <></>}
+
+          <span className="next-arrow" onClick={handleNextScroll}>&rsaquo;</span>
+
+        <ol id="tiles">
+          {relatedIds.map((id) => (
+            <RelatedProductTile currentId={currentProductId} relId={id} key={id}/>
+          ))}
+        </ol>
+
+      </div>
     </div>
   );
 };

--- a/src/components/RelatedProducts.js
+++ b/src/components/RelatedProducts.js
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
-import RelatedProductTile from './RelatedProductTile';
+import ProductTile from './ProductTile';
 
 const RelatedProducts = () => {
 
@@ -37,19 +37,20 @@ const RelatedProducts = () => {
 
   return (
     <div>
-      <span>Related Products</span>
+      <span id="RP-title">Related Products</span>
       <div id="RP-wrapper">
-          {scrollPos !== 0 ?
-          <span className="prev-arrow" onClick={handlePrevScroll}>&lsaquo;</span> :
-          <></>}
-
-          <span className="next-arrow" onClick={handleNextScroll}>&rsaquo;</span>
 
         <ol id="tiles">
           {relatedIds.map((id) => (
-            <RelatedProductTile currentId={currentProductId} relId={id} key={id}/>
+            <ProductTile tileType='related' currentId={currentProductId} relId={id} key={id}/>
           ))}
         </ol>
+
+        {scrollPos !== 0 ?
+        <span className="prev-arrow" onClick={handlePrevScroll}>&lsaquo;</span> :
+        <></>}
+
+        <span className="next-arrow" onClick={handleNextScroll}>&rsaquo;</span>
 
       </div>
     </div>

--- a/src/components/cart.jsx
+++ b/src/components/cart.jsx
@@ -2,14 +2,28 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 
+/*
+Issues as I understand:
+- when user selects size, the available QTYs do not populate immediately
+
+
+*/
 
 function Cart({style}) {
+  // API call to GET /products/id
   const [styleInfo, setStyleInfo] = useState([]);
-  const [qtyBySize, setQtyBySize] = useState([]);
+
+  // user selected size
   const [selectedSize, setSize] = useState('');
+  // ...updates qtys available in that size
+  const [qtyBySize, setQtyBySize] = useState([]);
+  // user selected qty to check out
   const [selectedQty, setQty] = useState('');
+  // all available sizes and qtys of that SKU
   const [skuDetail, setSkuDetail] = useState([]);
+  // when size selected, updates with {qty 16, size S}
   const [selectedSizeAndQty, setSelectedSizeAndQty] = useState({});
+  let selectedSizeQty = {};
 
   function getStyleInfo() {
     axios.get(`products/11001`)
@@ -32,18 +46,18 @@ function Cart({style}) {
     let qtyArray = [];
 
     if (sizeQtyObj !== undefined) {
-    setSize(sizeQtyObj.size);
+      setSize(sizeQtyObj.size);
     if (sizeQtyObj.quantity > 15) {
       for(let i = 1; i < 15; i++) {
       qtyArray.push(i);
     }
-  } else {
-    for(let i = 1; i < sizeQtyObj.quantity; i++) {
-      qtyArray.push(i);
+    } else {
+      for(let i = 1; i < sizeQtyObj.quantity; i++) {
+        qtyArray.push(i);
+      }
     }
-  }
-  setQtyBySize(qtyArray)
-}
+      setQtyBySize(qtyArray)
+    }
   }
 
   function getSizeAndQty(sizeIndex) {
@@ -59,7 +73,10 @@ function Cart({style}) {
 {/* //{quantity: 15, size: "XL"} */}
 
     setSelectedSizeAndQty(skuDetail[sizeIndex]);
-    assignSizeAndQty(selectedSizeAndQty)
+    selectedSizeQty = skuDetail[sizeIndex];
+
+    // assignSizeAndQty(selectedSizeAndQty)
+    assignSizeAndQty(selectedSizeQty)
 
   }
 
@@ -67,10 +84,10 @@ function Cart({style}) {
 
 
   useEffect(() => {
-    getStyleInfo()
-    getSkuDetail(style.skus)
-    assignSizeAndQty()
-    getSizeAndQty()
+    getStyleInfo() // fetch prod desc by id
+    getSkuDetail(style.skus) // all qty/size combos
+    // assignSizeAndQty()
+    // getSizeAndQty()
 
   }, [])
 

--- a/src/components/tiles-subcomps/StarRatings.js
+++ b/src/components/tiles-subcomps/StarRatings.js
@@ -3,7 +3,7 @@ import React from 'react';
 /* StarRatings expects an object props with a rating property:
 
     {
-      rating: 3.33
+      ratings: 3.33
     }
 
   This component relies on :root and .Stars scss rules defined inside of styles.scss

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,12 +1,12 @@
-*{
+* {
   margin: 0px;
   padding: 0px;
   box-sizing: border-box;
 }
 
 body {
-  font-family: sans-serif;
-  font-size: 25px;
+  font-family: helvetica;
+  font-size: 16px;
   width: 100%;
   min-height: 100vh;
 }
@@ -31,14 +31,12 @@ h1 {
   flex-direction: row;
   gap: 20px;
   justify-content: space-evenly;
-
 }
 
 .styleInfo {
   display: flex;
   flex-direction: column;
   gap: 20px;
-
 }
 
 .thumbnails {
@@ -46,13 +44,11 @@ h1 {
   display: flex;
   flex-direction: row;
   gap: 5px;
-
 }
 
 .thumbnailList {
   width: 100%;
   min-height: 20%;
-
 }
 
 .salePrice {
@@ -68,7 +64,6 @@ h1 {
   flex-direction: row;
   gap: 5px;
   font-size: 15px;
-
 }
 
 .sizeOptions {
@@ -76,9 +71,4 @@ h1 {
   flex-direction: row;
   gap: 5px;
   font-size: 15px;
-
 }
-
-
-
-

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,45 +1,59 @@
 //// TILES ////
 
-#tiles {
-  list-style-type: none;
-  width: 45vw;
-  display: flex;
-  justify-content: space-between;
-  overflow-x: scroll;
-  flex-wrap: nowrap;
-  scroll-snap-type: x mandatory;
-  column-gap: 5px;
-  scroll-behavior: smooth;
+#RP-title {
+  display: block;
+  margin-bottom: 20px;
 }
 
-.tile {
+#RP-wrapper {
   display: flex;
-  flex: 0 0 calc(200px - 1em);
-  border: rgb(197, 197, 197) solid 1px;
-  height: 35vh;
-  flex-direction: column;
-  scroll-snap-align: center;
+  width: 55vw;
+  position: relative;
+  margin-bottom: 50px;
 }
 
 ::-webkit-scrollbar {
   display: none;
 }
 
-// #RP-wrapper {
-//   display: grid;
-//   grid-template-areas:
-//     'a a a a'
-//     'b a a c'
-//     'a a a a';
-// }
-
 .prev-arrow {
-  font-size: 100px;
+  z-index: 2;
+  position: absolute;
+  left: 1%;
+  top: 30%;
+  font-size: 50px;
+  color: white;
 }
 
 .next-arrow {
-  color: red;
-  font-size: 100px;
+  z-index: 2;
+  position: absolute;
+  left: 97%;
+  top: 30%;
+  font-size: 50px;
+  color: white;
+}
+
+#tiles {
+  list-style-type: none;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  overflow-x: scroll;
+  flex-wrap: nowrap;
+  scroll-snap-type: x mandatory;
+  column-gap: 12px;
+  scroll-behavior: smooth;
+  grid-area: 'mid';
+}
+
+.tile {
+  display: flex;
+  flex: 0 0 calc(200px - 1em);
+  border: rgb(197, 197, 197) solid 1px;
+  height: 40vh;
+  flex-direction: column;
+  scroll-snap-align: center;
 }
 
 .tile-img-container {
@@ -54,19 +68,23 @@
 }
 
 .tile-texts-container {
-  flex: 0 0 35%;
+  flex: 0 0 25%;
   display: flex;
   flex-direction: column;
+  position: relative;
+  margin: 7px;
 }
 
 .tile-category {
-  flex: 0 0 25%;
+  flex: 0 0 35%;
   color: rgb(122, 122, 122);
   font-size: 0.7em;
+  text-transform: uppercase;
 }
 
 .tile-name {
   flex: 0 0 25%;
+  margin-bottom: 5px;
 }
 
 .tile-price {
@@ -102,7 +120,8 @@
   font-family: Times;
   font-size: var(--star-size);
   flex: 0 0 10%;
-  // line-height: 1;
+  margin-bottom: 5px;
+  margin-left: 6px;
 
   &::before {
     content: '★★★★★';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,96 @@
+//// TILES ////
+
+#tiles {
+  list-style-type: none;
+  width: 45vw;
+  display: flex;
+  justify-content: space-between;
+  overflow-x: scroll;
+  flex-wrap: nowrap;
+  scroll-snap-type: x mandatory;
+  column-gap: 5px;
+  scroll-behavior: smooth;
+}
+
+.tile {
+  display: flex;
+  flex: 0 0 calc(200px - 1em);
+  border: rgb(197, 197, 197) solid 1px;
+  height: 35vh;
+  flex-direction: column;
+  scroll-snap-align: center;
+}
+
+::-webkit-scrollbar {
+  display: none;
+}
+
+// #RP-wrapper {
+//   display: grid;
+//   grid-template-areas:
+//     'a a a a'
+//     'b a a c'
+//     'a a a a';
+// }
+
+.prev-arrow {
+  font-size: 100px;
+}
+
+.next-arrow {
+  color: red;
+  font-size: 100px;
+}
+
+.tile-img-container {
+  flex: 0 0 60%;
+  overflow: hidden;
+}
+
+.tile-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.tile-texts-container {
+  flex: 0 0 35%;
+  display: flex;
+  flex-direction: column;
+}
+
+.tile-category {
+  flex: 0 0 25%;
+  color: rgb(122, 122, 122);
+  font-size: 0.7em;
+}
+
+.tile-name {
+  flex: 0 0 25%;
+}
+
+.tile-price {
+  flex: 0 0 25%;
+  color: rgb(122, 122, 122);
+  font-size: 0.7em;
+}
+
+.sale-price {
+  color: red;
+}
+
+.full-price {
+  text-decoration: line-through;
+}
+
+.tile-stars {
+  flex: 0 0 25%;
+}
+
+//// StarRatings ////
+
 :root {
-  --star-size: 20px;
+  --star-size: 15px;
   --star-color: rgb(168, 168, 168);
   --star-background: rgb(24, 24, 24);
 }
@@ -10,6 +101,7 @@
   display: inline-block;
   font-family: Times;
   font-size: var(--star-size);
+  flex: 0 0 10%;
   // line-height: 1;
 
   &::before {

--- a/store/store.js
+++ b/store/store.js
@@ -7,7 +7,7 @@ export default createStore(
   rootReducer,
   {
     styleList: {
-      product_id: '11001',
+      product_id: '11003',
       results: [
         {
           style_id: 51158,


### PR DESCRIPTION
Hi @amandaklein1 ! This PR mainly contains my new scrolling feature for the Related Products widget. I also attempted to fix the bug you were encountering in cart.jsx.

If you take a look at cart.jsx, you'll see that I introduced a local variable 'selectedSizeQty' on line 26, which takes on the role of your original 'selectedSizeAndQty' local state. Then on line 76 I assign 'skuDetail[sizeIndex]' to the local variable so that it can be immediately accessed and used as argument to assignSizeAndQty fn on line 79. I believe that fixes the bug, and all sizes become available immediately now when the user selects a size from the dropdown. 

I also noticed on line 89 and 90 that we can forgo calling 'assignSizeAndQty()' and 'getSizeAndQty()' in useEffect since these fns aren't needed yet upon page mounting.

The issue does seem to be with how Hooks doesn't immediately make a local state accessible even though it is set. The original 'setSelectedSizeAndQty' state does work properly but its counterpart 'selectedSizeAndQty' does not refresh until next rerender. STRANGE!

Hope this works the way you expected and lemme know if I can do anything else.